### PR TITLE
Display all RGB values in the status-bar + Horizontal-Scroll for scrolling through batch samples

### DIFF
--- a/numpyviewer.pro
+++ b/numpyviewer.pro
@@ -71,7 +71,9 @@ ICON = artwork/icon.icns
 #INCLUDEPATH += "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
 
 # AppImage / Linux support
-LIBS += -lz
+!win32 {
+    LIBS += -lz
+}
 CONFIG += c++11
 
 # Windows

--- a/src/graphics_view_zoom.h
+++ b/src/graphics_view_zoom.h
@@ -2,6 +2,8 @@
 #define GRAPHICS_VIEW_ZOOM_H
 #include <QObject>
 #include <QGraphicsView>
+#include <QtDebug>
+#include <QtWidgets/QSlider>
 
 /*!
  * This class adds ability to zoom QGraphicsView using mouse wheel. The point under cursor
@@ -47,6 +49,7 @@ private:
     double _zoom_factor_base;
     QPointF target_scene_pos, target_viewport_pos;
     bool eventFilter(QObject* object, QEvent* event);
+    int _horizontal_scroll_accumulator;
 
 signals:
     void zoomed();


### PR DESCRIPTION
I have added 2 user-enhancement, plus one "necessary" fix to be able to compile the project under Windows. 

Enhancements:
 - in the RGB (or BGR) display mode, all three channel values are displayed in the status-bar
 - added capability of horizontal-scroll to list through individual batch examples
   - by-default, scrolling goes one-by-one, but the implementation also allows for "fast scrolling" using the Shift key. 
 
Project modification:
 - in Windows, the directive `LIBS += -lz` causes build problem: "`LINK : fatal error LNK1104: cannot open file 'z.lib'`". I added conditional directives, that excludes the zlib linking on Windows (still, it should be linked on Linux/Mac -- please test it if you care). 
